### PR TITLE
feat: support aws web identity token file

### DIFF
--- a/lib/plugins/sqsMessageQueue/lib/SQSMessageQueue.js
+++ b/lib/plugins/sqsMessageQueue/lib/SQSMessageQueue.js
@@ -3,6 +3,7 @@
  *
  * @description the services for connecting rabbit message queue
  */
+const fs = require('fs')
 const _ = require('lodash')
 const Promise = require('bluebird')
 
@@ -23,6 +24,17 @@ class SQSMessageQueue {
     }
   }
 
+  get authProvider() {
+    if (process.env.AWS_WEB_IDENTITY_TOKEN_FILE) {
+      return {
+        sessionToken: fs
+          .readFileSync(process.env.AWS_WEB_IDENTITY_TOKEN_FILE)
+          .toString(),
+      }
+    }
+    return _.pick(this.config, ['accessKeyId', 'secretAccessKey'])
+  }
+
   get sqs() {
     if (!this.singleSqs) {
       if (!this.config) return null
@@ -30,10 +42,9 @@ class SQSMessageQueue {
       const { accessKeyId, secretAccessKey, apiVersion, region } = this.config
 
       this.singleSqs = new this.aws.SQS({
-        accessKeyId,
-        secretAccessKey,
         apiVersion,
-        region
+        region,
+        ...this.authProvider,
       })
     }
 


### PR DESCRIPTION
## Summary
調整 `SQSMessageQueue` 可以從 `process.env.AWS_WEB_IDENTITY_TOKEN_FILE` 讀取 credential，這樣才能在 EKS 環境下使用 service account 的權限。