### PR TITLE
修正 QueueTask 內的錯誤

### DIFF
--- a/lib/services/QueueTask.js
+++ b/lib/services/QueueTask.js
@@ -51,7 +51,7 @@ class QueueTask {
 
   static async create(obj) {
     const queueTask = new this(obj)
-    const { messageExpireTimeSec } = this.constructor.taskQueues[queueTask.taskType];
+    const { messageExpireTimeSec } = this.taskQueues[queueTask.taskType];
 
     queueTask.validate()
 


### PR DESCRIPTION
## Summary
`QueueTask.create` 在存取 `QueueTask.taskQueues` 時誤寫成了 `this.constructor.taskQueues`，應該修正為 `this.taskQueues`。

## Related PRs
- https://github.com/shoplineapp/sl-express/pull/112