### PR TITLE
Handle sigterm and do graceful shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - plugin appending properties to app is not appropriate (Ted)
 
 ### changed
+- add graceful shutdown support for both express & consumer
+- add `willStopService` plugin phase and let SQSMessageQueue stop polling when willStopService
+- fix logging typo
 - BREAKING: change SQSMessageQueue to use EnvironmentCredential with SQS prefix + default provider. Credential from env has higher priority than from k8s service account.
 
 ## [3.2.1] 2021-10-13

--- a/lib/models/App.js
+++ b/lib/models/App.js
@@ -522,6 +522,8 @@ class App {
 
     await this.startService()
 
+    process.on('SIGTERM', this.stop.bind(this))
+
     await this.executePluginPhase('didStartService')
 
     return this
@@ -536,6 +538,8 @@ class App {
    */
 
   async stop() {
+
+    await this.executePluginPhase('willStopService')
 
     await this.stopService()
 

--- a/lib/models/App.js
+++ b/lib/models/App.js
@@ -539,6 +539,8 @@ class App {
 
   async stop() {
 
+    console.log('##### app will stop #####')
+
     await this.executePluginPhase('willStopService')
 
     await this.stopService()

--- a/lib/plugins/sqsMessageQueue/lib/MessageQueuePlugin.js
+++ b/lib/plugins/sqsMessageQueue/lib/MessageQueuePlugin.js
@@ -16,19 +16,27 @@ class MessageQueuePlugin {
   }
 
   async connectDependencies(app) {
-    log('system', 'info', { messsage: 'connecting SQSMessageQueue' })
+    log('system', 'info', { message: 'connecting SQSMessageQueue' })
 
     await this.messageQueue.connect()
 
-    log('system', 'info', { messsage: 'MessageQueue connected' })
+    log('system', 'info', { message: 'MessageQueue connected' })
   }
 
   async disconnectDependencies(app) {
-    log('system', 'info', { messsage: 'disconnecting SQSMessageQueue' })
+    log('system', 'info', { message: 'disconnecting SQSMessageQueue' })
 
     await this.messageQueue.close()
 
-    log('system', 'info', { messsage: 'MessageQueue disconnected' })
+    log('system', 'info', { message: 'MessageQueue disconnected' })
+  }
+
+  async willStopService(app) {
+    log('system', 'info', { message: 'destroy SQSMessageQueue' })
+
+    await this.messageQueue.stop()
+
+    log('system', 'info', { message: 'MessageQueue destroying' })
   }
 }
 

--- a/lib/plugins/sqsMessageQueue/lib/SQSMessageQueue.js
+++ b/lib/plugins/sqsMessageQueue/lib/SQSMessageQueue.js
@@ -117,6 +117,7 @@ class SQSMessageQueue {
   }
 
   stop() {
+    this.log('SQS', 'trace', { message: 'stop polling messages' })
     this.paused = true
     return this
   }

--- a/lib/plugins/sqsMessageQueue/lib/SQSMessageQueue.js
+++ b/lib/plugins/sqsMessageQueue/lib/SQSMessageQueue.js
@@ -9,6 +9,7 @@ const Promise = require('bluebird')
 
 class SQSMessageQueue {
   constructor(obj) {
+    this.paused = false
     this.aws = require('aws-sdk')
 
     Object.assign(this, {
@@ -115,6 +116,11 @@ class SQSMessageQueue {
     return null
   }
 
+  stop() {
+    this.paused = true
+    return this
+  }
+
   async queueMessage(queueId, message) {
     const queue = this.sqsQueuesDict[this.config.queueMap[queueId]]
     const timeBeforeSend = new Date()
@@ -175,9 +181,12 @@ class SQSMessageQueue {
 
   async getMessage(queue, params, handler) {
     let data
+    if (this.paused) {
+      return
+    }
     try {
       data = await this.sqs.receiveMessage(params).promise()
-      if (!data.Messages || data.Messages === 0) {
+      if (!data.Messages || data.Messages.length === 0) {
         return this.getMessage(queue, params, handler)
       }
 


### PR DESCRIPTION
## Summary

1. 原先的寫法在接收到 `SIGTERM` 的時候 service 不會做結束的準備，調整為在啟動完成後監聽 `SIGTERM`，並且在接收到 SIGTERM 時觸發 `App.prototype.stop`。
2. 新增一個 plugin phase `willStopService`，這個 phase 會在 `App.prototype.stop` 最一開始的時候執行，然後才會執行 `App.prototype.stopService`，最後才會進到 `disconnectDependencies` phase。
3. 調整 `SQSMessageQueue` 在 `willStopService` 後不會再繼續從 SQS 拿取新的 message。
3. 修正一些 typo