### PR TITLE
bump version into 3.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - More powerful hooking for app phasing (mentioned By Philip)
 - plugin appending properties to app is not appropriate (Ted)
 
+## [3.3.0] 2021-11-03
 ### changed
 - add graceful shutdown support for both express & consumer
 - add `willStopService` plugin phase and let SQSMessageQueue stop polling when willStopService

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shopline/sl-express",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "A nodejs framework based on expressjs",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
## [3.3.0] 2021-11-03
### changed
- add graceful shutdown support for both express & consumer
- add `willStopService` plugin phase and let SQSMessageQueue stop polling when willStopService
- fix logging typo
- BREAKING: change SQSMessageQueue to use EnvironmentCredential with SQS prefix + default provider. Credential from env has higher priority than from k8s service account.