### PR TITLE
feat(SQSMessageQueue): handle got message after 20s but pod is shutting down issue

### DIFF
--- a/lib/plugins/sqsMessageQueue/lib/SQSMessageQueue.js
+++ b/lib/plugins/sqsMessageQueue/lib/SQSMessageQueue.js
@@ -11,6 +11,7 @@ class SQSMessageQueue {
   constructor(obj) {
     this.paused = false
     this.messageInProcessing = false
+    this.isFetchingMessage = false
     this.aws = require('aws-sdk')
 
     Object.assign(this, {
@@ -116,7 +117,7 @@ class SQSMessageQueue {
   async close() {
     this.log('SQS', 'trace', { message: 'close SQSMessageQueue' })
 
-    if (!this.messageInProcessing) {
+    if (!this.messageInProcessing && !this.isFetchingMessage) {
       return null
     } else {
       this.log('SQS', 'trace', { message: 'waiting processing message' })
@@ -193,6 +194,25 @@ class SQSMessageQueue {
     return this.getMessage(queue, params, handler)
   }
 
+  changeVisibilityTimeout(queueUrl, messages) {
+    const promiseHandleMessage = messages.map(async(msg) => {
+
+      this.log('SQS', 'trace', { message: 'Start changeVisibilityTimeout', queueUrl })
+
+      const changeParams = {
+        QueueUrl: queueUrl,
+        ReceiptHandle: msg.ReceiptHandle,
+        VisibilityTimeout: 0
+      }
+
+      await this.sqs.changeMessageVisibility(changeParams).promise()
+
+      this.log('SQS', 'trace', { message: 'Finish changeVisibilityTimeout', queueUrl })
+    })
+
+    return Promise.all(promiseHandleMessage);
+  }
+
   async getMessage(queue, params, handler) {
     let data
     if (this.paused) {
@@ -200,11 +220,21 @@ class SQSMessageQueue {
     }
 
     try {
+      this.isFetchingMessage = true
       data = await this.sqs.receiveMessage(params).promise()
       if (!data.Messages || data.Messages.length === 0) {
         return this.getMessage(queue, params, handler)
       }
 
+      // Handle Race Condition Case
+      // (got message after 20s waiting time, but pod is shutting down, set message to visible)
+      if (this.paused) {
+        await this.changeVisibilityTimeout(queue.queueUrl, data.Messages)
+        this.isFetchingMessage = false
+        return
+      }
+
+      this.isFetchingMessage = false
       this.messageInProcessing = true
 
       const promiseHandleMessage = data.Messages.map(async(msg) => {

--- a/lib/plugins/sqsMessageQueue/lib/SQSMessageQueue.js
+++ b/lib/plugins/sqsMessageQueue/lib/SQSMessageQueue.js
@@ -262,6 +262,7 @@ class SQSMessageQueue {
     } catch (err) {
       this.log('SQS', 'error', { err, data })
       this.messageInProcessing = false
+      this.isFetchingMessage = false
       return this.getMessage(queue, params, handler)
     }
   }


### PR DESCRIPTION
WHY?

Encountered issue: The consumer received sigterm, initiating shutdown process

Before pod terminated, consumer received a message after 20 seconds of waiting time (waitTimeSeconds). Therefore, the message needs to wait until the visible timeout

HOW?

1. Add isFetchingMessage flag to check if  all getMessage method finished
2. changeMessageVisibility to zero if pod is paused