### PR TITLE
feat: use bluebird promise for internal usage only

### DIFF
--- a/lib/models/App.js
+++ b/lib/models/App.js
@@ -5,7 +5,6 @@
  */
 
 let deepExtend = require('deep-extend');
-let Promise = require('bluebird')
 let path = require('path')
 let PluginService = require('../services/PluginService.js')
 const AppHelper = require('./AppHelper.js')
@@ -419,8 +418,6 @@ class App {
 
   async prepare() {
     this.loadConfig()
-
-    this.context.Promise = Promise
 
     this.loadFramework()
     this.loadPlugins()

--- a/lib/plugins/mongoose/lib/MongoosePlugin.js
+++ b/lib/plugins/mongoose/lib/MongoosePlugin.js
@@ -1,9 +1,6 @@
-const Promise = require('bluebird')
-
 class MongoosePlugin {
   didLoadFramework(app) {
     const mongoose = require('mongoose')
-    mongoose.Promise = Promise
 
     const {
       config: { mongoose: config }

--- a/lib/plugins/mongooseAtlas/lib/MongooseAtlasPlugin.js
+++ b/lib/plugins/mongooseAtlas/lib/MongooseAtlasPlugin.js
@@ -1,9 +1,6 @@
-const Promise = require('bluebird')
-
 class MongooseAtlasPlugin {
   didLoadFramework(app) {
     const mongoose = require('mongoose')
-    mongoose.Promise = Promise
 
     const {
       config: { mongooseAltas: config },

--- a/lib/plugins/redis/lib/Redis.js
+++ b/lib/plugins/redis/lib/Redis.js
@@ -1,3 +1,5 @@
+const Promise = require('bluebird');
+
 let _sharedRedis = null
 let _redisLib
 

--- a/lib/services/PluginService.js
+++ b/lib/services/PluginService.js
@@ -1,3 +1,4 @@
+const Promise = require('bluebird');
 class PluginService {
   constructor({
     dirs = [],

--- a/lib/services/QueueTask.js
+++ b/lib/services/QueueTask.js
@@ -1,3 +1,4 @@
+const Promise = require('bluebird');
 const AppError = require('./AppError.js')
 class QueueTaskNotFoundError extends AppError {}
 class QueueTaskTriggerError extends AppError {}


### PR DESCRIPTION
adjust that bluebird promise is set to global, cause the newer version (8.3.2) of mongoose will raise exception if global promise is bluebird.


reason:
<img width="823" alt="image" src="https://github.com/shoplineapp/sl-express/assets/11512544/8d7bafad-c817-4dee-9245-c515a8fb5612">

in mongoose package:
<img width="533" alt="image" src="https://github.com/shoplineapp/sl-express/assets/11512544/6336913b-29ad-42e0-8a90-39107f502d7b">
